### PR TITLE
Add month and year selection for schedule scraping

### DIFF
--- a/src/calendar_converter.py
+++ b/src/calendar_converter.py
@@ -1,14 +1,27 @@
 from webscraper import scrape_schedule, fetch_html_content
 from calendar_events import create_event, get_calendar_service, verify_calendar_exists
+from datetime import datetime
 import getpass
-import datetime
 
 name = input("Enter your first name (capitalized first letter): ")
 username = input("Enter your Crew Quarters username: ")
 password = getpass.getpass("Enter your password (input hidden): ")
 
-shifts = scrape_schedule(username, password, name)
-print(shifts)
+month = input("Enter the month to scrape (1-12, default current month): ")
+if month:
+    month = int(month)
+else:
+    month = datetime.now().month
+
+year = input("Enter the year to scrape (e.g., 2024, default current year): ")
+
+if year:
+    year = int(year)
+else:
+    year = datetime.now().year
+
+# print("Scraping schedule for {name} for month {month}/{year}".format(name = name, month = month, year = year))
+shifts = scrape_schedule(username, password, name, month, year)
 print("Schedule scraping completed successfully. \n\n")
 
 calendar_name = input("Enter the wanted calendar name: ")
@@ -16,9 +29,5 @@ calendar_name = input("Enter the wanted calendar name: ")
 service = get_calendar_service()
 calendar_id = verify_calendar_exists(service, calendar_name)
 
-
 for shift in shifts:
-    # print(shift)
-    # print("\n")
     create_event(service, calendar_id, shift["date"], shift["time"], shift["shift"])
-# create_event(service, calendar_id, shifts["date"], shifts["time"], shifts["shift"])

--- a/src/calendar_events.py
+++ b/src/calendar_events.py
@@ -1,6 +1,5 @@
 import datetime
 import os.path
-
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -114,7 +113,7 @@ def verify_calendar_exists(service, calendar_name):
 
 
 # If modifying these scopes, delete the file token.json.
-SCOPES = ["https://www.googleapis.com/auth/calendar.app.created", "https://www.googleapis.com/auth/calendar.calendarlist.readonly"]
+SCOPES = ["https://www.googleapis.com/auth/calendar.app.created", "https://www.googleapis.com/auth/calendar.calendarlist.readonly", "https://www.googleapis.com/auth/calendar.events.owned"]
 
 
 def main():
@@ -127,4 +126,3 @@ def main():
     create_event(service, emt_calendar_id, datetime.date(2026, 3, 13), "PM", "Third")
   except HttpError as error:
     print("An error occurred: %s" % error)
-# main()

--- a/src/webscraper.py
+++ b/src/webscraper.py
@@ -6,16 +6,20 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
 import time
 
-def fetch_html_content(username, password):
+def fetch_html_content(username, password, month, year):
     """
     Uses Selenium to log in and fetch the fully rendered HTML of the calendar page.
 
     @param username: Crew Quarters username
     @param password: Crew Quarters password
+    @param month: Month to scrape
+    @param year: Year to scrape
     @return: HTML content of the schedule page as a string
     """
     login_url = "https://stevensems.com/cq/index.php?v=login_form&iframe=true"
-    calendar_url = "https://stevensems.com/cq/index.php?p=calendar"
+    calendar_url = "https://stevensems.com/cq/index.php?p=calendar&cal_month={month}&cal_year={year}".format(month = month, year = year)
+
+    print(calendar_url)
 
     # Setup Chrome headless (runs in background)
     chrome_options = Options()
@@ -51,7 +55,6 @@ def fetch_html_content(username, password):
         # Prevent real crashes if things go sideways
         # Close the browser after fetching the content
         driver.quit()
-
 
 def extract_shift_details(shift_element):
     """
@@ -134,16 +137,17 @@ def extract_all_shifts(html_page, name):
 
     return shifts
 
-# TODO: Main scraping function to orchestrate the entire workflow
-def scrape_schedule(username, password, name):
+def scrape_schedule(username, password, name, month, year):
     """
     Main function to scrape the schedule for a specific user.
 
     @param username: Crew Quarters username
     @param password: Crew Quarters password
     @param name: First name of the user to filter shifts
+    @param month: Month to scrape (default is current month)
+    @param year: Year to scrape (default is current year)
     """
-    html_page = str(fetch_html_content(username, password))
+    html_page = str(fetch_html_content(username, password, month, year))
     shifts = extract_all_shifts(html_page, name)
     print(f"Extracted {len(shifts)} shifts from the schedule.")
     return shifts


### PR DESCRIPTION
Updates the CLI and scraper to fetch schedules for a specific month and year via URL parameters. Includes the necessary Google Calendar scope for the updated event management.

resolves #11 